### PR TITLE
docs: drop rewrite-branch pin from CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ddd-sample-scala
 
-[![CI](https://github.com/oluies/ddd-sample-scala/actions/workflows/ci.yml/badge.svg?branch=rewrite/from-java-master)](https://github.com/oluies/ddd-sample-scala/actions/workflows/ci.yml)
+[![CI](https://github.com/oluies/ddd-sample-scala/actions/workflows/ci.yml/badge.svg)](https://github.com/oluies/ddd-sample-scala/actions/workflows/ci.yml)
 [![Scala](https://img.shields.io/badge/scala-3.3.4_LTS-DC322F?logo=scala&logoColor=white)](https://www.scala-lang.org/)
 [![Java](https://img.shields.io/badge/java-21-007396?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
 [![Spring Boot](https://img.shields.io/badge/spring%20boot-3.3.10-6DB33F?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)


### PR DESCRIPTION
## Summary

Follow-up to #95. The CI badge in README was pinned to
`?branch=rewrite/from-java-master` while the rewrite was in flight;
that branch was merged into master in #95 so the pin is now stale.
Removed it so the badge tracks the default branch.

## Test plan

- [ ] CI run on this branch passes the `mill test (Java 21)` check (required by branch protection)
- [ ] After merge, the badge on master's README points at the workflow's overall status (latest run on master)