### PR TITLE
poc: Magnum-backed CargoRepository (phase 9b option A)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -73,13 +73,21 @@ object ddd extends ScalaModule with ScalafmtModule {
     // attacker reaching the queue can't pivot through Java deserialization
     // of `scala.Some` / `scala.None` etc.). Version-aligned with the
     // Jackson 2.18.x that Spring Boot 3.3.10 brings in transitively.
-    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.18.2"
+    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.18.2",
+    // Magnum + H2 — PoC for the Magnum-based phase 9b persistence layer.
+    // Lives alongside the in-memory repos; not yet wired into Spring beans
+    // (the in-memory `@Repository`-annotated impls are still authoritative).
+    // Exercised end-to-end via MagnumCargoRepositoryTest against H2 in-memory.
+    mvn"com.augustnagro::magnum:1.3.1",
+    mvn"com.h2database:h2:2.3.232"
   )
 
   object test extends ScalaTests with TestModule.ScalaTest with ScalafmtModule {
     // Tests live in `src/test/scala` per the Maven/sbt layout, not Mill's
     // default of `ddd/test/src`.
     override def sources = Task.Sources(mill.api.BuildCtx.workspaceRoot / "src" / "test" / "scala")
+    override def resources =
+      Task.Sources(mill.api.BuildCtx.workspaceRoot / "src" / "test" / "resources")
 
     def mvnDeps = Seq(
       mvn"org.springframework.boot:spring-boot-starter-test:$SpringBootVersion"

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/CargoRow.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/CargoRow.scala
@@ -1,0 +1,46 @@
+package se.citerus.dddsample.infrastructure.persistence.magnum
+
+import java.time.Instant
+
+import com.augustnagro.magnum.*
+
+import se.citerus.dddsample.infrastructure.persistence.magnum.MagnumCodecs.given
+
+/**
+ * Persistence model for the Cargo aggregate root.
+ *
+ * Pure data — no domain methods, no JPA annotations, no `var` fields.
+ * Magnum derives a `DbCodec` at compile time that maps these fields to
+ * columns in the `cargo` table. Mapping between this row and the domain
+ * [[se.citerus.dddsample.domain.model.cargo.Cargo]] aggregate lives in
+ * [[MagnumCargoRepository]].
+ *
+ * Cross-aggregate references stored by **id** (UN/Locode, voyage number)
+ * — matches the DDD recommendation that aggregates reference each other
+ * by id, not by object. The domain's `Cargo` then resolves those ids via
+ * the `Location` / `Voyage` repositories during rehydration.
+ *
+ * The `Delivery` snapshot is **not** persisted. It is re-derived from
+ * `RouteSpecification` + `Itinerary` + the cargo's handling history every
+ * time a `Cargo` is loaded — mirroring `Cargo.deriveDeliveryProgress` —
+ * which keeps storage normalized and avoids stale snapshots.
+ */
+@Table(H2DbType, SqlNameMapper.CamelToSnakeCase)
+final case class CargoRow(
+    @Id id: Long,
+    trackingId: String,
+    originUnLocode: String,
+    specDestinationUnLocode: String,
+    specArrivalDeadline: Instant
+) derives DbCodec
+
+/**
+ * The fields needed to *insert* a new Cargo row. Magnum's `Repo` typeclass
+ * takes a separate creator type so id-on-write is the database's job.
+ */
+final case class CargoCreator(
+    trackingId: String,
+    originUnLocode: String,
+    specDestinationUnLocode: String,
+    specArrivalDeadline: Instant
+) derives DbCodec

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/LegRow.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/LegRow.scala
@@ -1,0 +1,40 @@
+package se.citerus.dddsample.infrastructure.persistence.magnum
+
+import java.time.Instant
+
+import com.augustnagro.magnum.*
+
+import se.citerus.dddsample.infrastructure.persistence.magnum.MagnumCodecs.given
+
+/**
+ * Persistence model for one entry in a Cargo's `Itinerary`.
+ *
+ * Stored in a separate `leg` table joined back to `cargo` by FK. The
+ * `legIndex` column preserves leg order on rehydration without relying on
+ * insert order. References to other aggregates are by id:
+ *
+ *   - `voyageNumber`     → resolved via `VoyageRepository`
+ *   - `loadUnLocode`     → resolved via `LocationRepository`
+ *   - `unloadUnLocode`   → resolved via `LocationRepository`
+ */
+@Table(H2DbType, SqlNameMapper.CamelToSnakeCase)
+final case class LegRow(
+    @Id id: Long,
+    cargoId: Long,
+    legIndex: Int,
+    voyageNumber: String,
+    loadUnLocode: String,
+    unloadUnLocode: String,
+    loadTime: Instant,
+    unloadTime: Instant
+) derives DbCodec
+
+final case class LegCreator(
+    cargoId: Long,
+    legIndex: Int,
+    voyageNumber: String,
+    loadUnLocode: String,
+    unloadUnLocode: String,
+    loadTime: Instant,
+    unloadTime: Instant
+) derives DbCodec

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCargoRepository.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCargoRepository.scala
@@ -1,0 +1,169 @@
+package se.citerus.dddsample.infrastructure.persistence.magnum
+
+import java.util.UUID
+import javax.sql.DataSource
+
+import com.augustnagro.magnum.*
+
+import se.citerus.dddsample.domain.model.cargo.*
+import se.citerus.dddsample.domain.model.handling.HandlingEventRepository
+import se.citerus.dddsample.domain.model.location.{LocationRepository, UnLocode}
+import se.citerus.dddsample.domain.model.voyage.{VoyageNumber, VoyageRepository}
+import se.citerus.dddsample.infrastructure.persistence.magnum.MagnumCodecs.given
+
+/**
+ * Magnum-backed [[CargoRepository]] — proof-of-concept for phase 9b.
+ *
+ * Lives alongside `InMemoryCargoRepository`; not yet wired into Spring
+ * beans. Activation will be a `@Profile("magnum")` switch in a follow-up
+ * if we go ahead with the full 4-aggregate Magnum port.
+ *
+ * Design choices visible in this single file:
+ *
+ *   1. **Persistence model is immutable.** `CargoRow` / `LegRow` are case
+ *      classes with `derives DbCodec`; no `var`, no no-arg constructor,
+ *      no `@Entity` / `@OneToMany` annotations.
+ *
+ *   2. **Cross-aggregate references stored by id.** `voyageNumber`,
+ *      `loadUnLocode`, etc. are plain strings in storage; the adapter
+ *      resolves them to live `Voyage` / `Location` via their repositories
+ *      during rehydration. Cleaner aggregate boundary than the
+ *      object-reference shape inside the domain.
+ *
+ *   3. **`Delivery` is not persisted.** It is recomputed from the cargo's
+ *      handling history on every read (`Cargo.deriveDeliveryProgress`),
+ *      avoiding a snapshot that could drift from the source-of-truth
+ *      `HandlingEvent` aggregate.
+ *
+ *   4. **Transactions live in the adapter.** Each method opens its own
+ *      `transact(ds) { ... }` block. Application services drop
+ *      `@Transactional` once we adopt this layer wholesale — the storage
+ *      concern owns transactionality, which is arguably better DDD.
+ */
+final class MagnumCargoRepository(
+    ds: DataSource,
+    locationRepository: LocationRepository,
+    voyageRepository: VoyageRepository,
+    handlingEventRepository: HandlingEventRepository
+) extends CargoRepository:
+
+  // Magnum's Repo[EC, E, ID] typeclass: EC is the insert-time row, E the
+  // full row (with id), ID the primary-key type.
+  private val cargoRepo = Repo[CargoCreator, CargoRow, Long]
+  private val legRepo   = Repo[LegCreator, LegRow, Long]
+
+  override def find(trackingId: TrackingId): Option[Cargo] =
+    connect(ds):
+      sql"select * from cargo_row where tracking_id = ${trackingId.idString}"
+        .query[CargoRow]
+        .run()
+        .headOption
+        .map(rehydrate)
+
+  override def getAll: List[Cargo] =
+    connect(ds):
+      cargoRepo.findAll.toList.map(rehydrate)
+
+  override def store(cargo: Cargo): Unit =
+    transact(ds):
+      val existingId =
+        sql"select id from cargo_row where tracking_id = ${cargo.trackingId.idString}"
+          .query[Long]
+          .run()
+          .headOption
+
+      val cargoId = existingId match
+        case Some(id) =>
+          sql"""update cargo_row set
+                origin_un_locode = ${cargo.origin.unLocode.idString},
+                spec_destination_un_locode = ${cargo.routeSpecification.destination.unLocode.idString},
+                spec_arrival_deadline = ${cargo.routeSpecification.arrivalDeadline}
+                where id = $id""".update.run()
+          id
+        case None =>
+          // insertReturning gives us the generated key in one round-trip.
+          val inserted = cargoRepo.insertReturning(toCargoCreator(cargo))
+          inserted.id
+
+      // Itinerary is owned by the Cargo aggregate — refresh-by-replace is
+      // safe and avoids tracking individual leg-row deltas. Cheap because
+      // itineraries are short (handful of legs).
+      sql"delete from leg_row where cargo_id = $cargoId".update.run()
+      cargo.itineraryOpt.foreach { itin =>
+        itin.legs.zipWithIndex.foreach { case (leg, idx) =>
+          legRepo.insert(toLegCreator(cargoId, idx, leg))
+        }
+      }
+
+  override def nextTrackingId(): TrackingId =
+    TrackingId(UUID.randomUUID().toString.toUpperCase.substring(0, 10))
+
+  // ----- Row → Aggregate -------------------------------------------------
+
+  private def rehydrate(row: CargoRow)(using DbCon): Cargo =
+    val origin =
+      locationRepository
+        .find(UnLocode(row.originUnLocode))
+        .getOrElse(
+          throw new IllegalStateException(s"Unknown origin UN/Locode: ${row.originUnLocode}")
+        )
+    val destination =
+      locationRepository
+        .find(UnLocode(row.specDestinationUnLocode))
+        .getOrElse(
+          throw new IllegalStateException(
+            s"Unknown destination UN/Locode: ${row.specDestinationUnLocode}"
+          )
+        )
+    val spec = RouteSpecification(origin, destination, row.specArrivalDeadline)
+
+    val withSpec = Cargo(TrackingId(row.trackingId), spec)
+    val withItinerary = readLegs(row.id) match
+      case Some(itin) => withSpec.assignToRoute(itin)
+      case None       => withSpec
+
+    val history = handlingEventRepository.lookupHandlingHistoryOfCargo(withItinerary.trackingId)
+    withItinerary.deriveDeliveryProgress(history)
+
+  private def readLegs(cargoId: Long)(using DbCon): Option[Itinerary] =
+    val rows = sql"select * from leg_row where cargo_id = $cargoId order by leg_index"
+      .query[LegRow]
+      .run()
+    if rows.isEmpty then None
+    else
+      Some(Itinerary(rows.map { r =>
+        Leg(
+          voyageRepository
+            .find(VoyageNumber(r.voyageNumber))
+            .getOrElse(throw new IllegalStateException(s"Unknown voyage: ${r.voyageNumber}")),
+          locationRepository
+            .find(UnLocode(r.loadUnLocode))
+            .getOrElse(throw new IllegalStateException(s"Unknown load loc: ${r.loadUnLocode}")),
+          locationRepository
+            .find(UnLocode(r.unloadUnLocode))
+            .getOrElse(throw new IllegalStateException(s"Unknown unload loc: ${r.unloadUnLocode}")),
+          r.loadTime,
+          r.unloadTime
+        )
+      }.toList))
+
+  // ----- Aggregate → Row -------------------------------------------------
+
+  private def toCargoCreator(cargo: Cargo): CargoCreator =
+    CargoCreator(
+      trackingId = cargo.trackingId.idString,
+      originUnLocode = cargo.origin.unLocode.idString,
+      specDestinationUnLocode = cargo.routeSpecification.destination.unLocode.idString,
+      specArrivalDeadline = cargo.routeSpecification.arrivalDeadline
+    )
+
+  private def toLegCreator(cargoId: Long, legIndex: Int, leg: Leg): LegCreator =
+    LegCreator(
+      cargoId = cargoId,
+      legIndex = legIndex,
+      voyageNumber = leg.voyage.voyageNumber.idString,
+      loadUnLocode = leg.loadLocation.unLocode.idString,
+      unloadUnLocode = leg.unloadLocation.unLocode.idString,
+      loadTime = leg.loadTime,
+      unloadTime = leg.unloadTime
+    )

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCodecs.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCodecs.scala
@@ -1,0 +1,21 @@
+package se.citerus.dddsample.infrastructure.persistence.magnum
+
+import java.time.{Instant, ZoneOffset}
+
+import com.augustnagro.magnum.DbCodec
+
+/**
+ * Custom `DbCodec`s for types Magnum 1.3 doesn't ship by default.
+ *
+ * `Instant` is the type used throughout the domain for points in time
+ * (`HandlingEvent.completionTime`, `RouteSpecification.arrivalDeadline`,
+ * etc.). Magnum's built-in `OffsetDateTimeCodec` handles JDBC's
+ * `TIMESTAMP WITH TIME ZONE` natively, so we adapt that via `biMap`.
+ * All `Instant`s round-trip as UTC.
+ */
+object MagnumCodecs:
+
+  given DbCodec[Instant] = DbCodec.OffsetDateTimeCodec.biMap(
+    odt => odt.toInstant,
+    inst => inst.atOffset(ZoneOffset.UTC)
+  )

--- a/src/test/resources/magnum-cargo-schema.sql
+++ b/src/test/resources/magnum-cargo-schema.sql
@@ -1,0 +1,29 @@
+-- Schema for the Magnum CargoRepository PoC. Used by
+-- MagnumCargoRepositoryTest against H2 in-memory.
+--
+-- A future Flyway/Liquibase migration would manage this for production.
+-- For the PoC we ship it as a test resource and load it in @BeforeEach.
+--
+-- Table names follow Magnum's SqlNameMapper.CamelToSnakeCase mapping of
+-- the row case-class names: `CargoRow` → `cargo_row`, `LegRow` → `leg_row`.
+
+create table if not exists cargo_row (
+    id                         bigint generated always as identity primary key,
+    tracking_id                varchar(64) not null unique,
+    origin_un_locode           varchar(5)  not null,
+    spec_destination_un_locode varchar(5)  not null,
+    spec_arrival_deadline      timestamp with time zone not null
+);
+
+create table if not exists leg_row (
+    id               bigint generated always as identity primary key,
+    cargo_id         bigint      not null,
+    leg_index        int         not null,
+    voyage_number    varchar(64) not null,
+    load_un_locode   varchar(5)  not null,
+    unload_un_locode varchar(5)  not null,
+    load_time        timestamp with time zone not null,
+    unload_time      timestamp with time zone not null,
+    foreign key (cargo_id) references cargo_row (id) on delete cascade,
+    unique (cargo_id, leg_index)
+);

--- a/src/test/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCargoRepositoryTest.scala
+++ b/src/test/scala/se/citerus/dddsample/infrastructure/persistence/magnum/MagnumCargoRepositoryTest.scala
@@ -1,0 +1,201 @@
+package se.citerus.dddsample.infrastructure.persistence.magnum
+
+import java.time.Instant
+import javax.sql.DataSource
+
+import scala.io.Source
+import scala.util.Using
+
+import org.h2.jdbcx.JdbcDataSource
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import se.citerus.dddsample.domain.model.cargo.{
+  Cargo,
+  Itinerary,
+  Leg,
+  RouteSpecification,
+  RoutingStatus,
+  TrackingId,
+  TransportStatus
+}
+import se.citerus.dddsample.domain.model.handling.{HandlingEventRepository, HandlingHistory}
+import se.citerus.dddsample.domain.model.location.{Location, LocationRepository, UnLocode}
+import se.citerus.dddsample.domain.model.voyage.{
+  CarrierMovement,
+  Schedule,
+  Voyage,
+  VoyageNumber,
+  VoyageRepository
+}
+
+/**
+ * Integration test for the Magnum-based Cargo persistence layer.
+ *
+ * Uses a real H2 in-memory database — *not* the in-memory map. Each test
+ * gets a fresh schema; the location / voyage / handling-event collaborators
+ * are mocked so the test stays focused on the persistence round-trip.
+ *
+ * The point: exercise the actual SQL Magnum generates + the Row ↔ Aggregate
+ * mapper, end-to-end, against a real JDBC driver.
+ */
+class MagnumCargoRepositoryTest extends AnyFunSuite with Matchers with BeforeAndAfterEach:
+
+  private val SHA = Location(UnLocode("CNSHA"), "Shanghai")
+  private val RTM = Location(UnLocode("NLRTM"), "Rotterdam")
+  private val GOT = Location(UnLocode("SEGOT"), "Gothenburg")
+
+  private val deadline = Instant.parse("2026-12-01T00:00:00Z")
+
+  private val voyage = new Voyage(
+    VoyageNumber("V1"),
+    Schedule(
+      List(
+        CarrierMovement(SHA, RTM, Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)),
+        CarrierMovement(RTM, GOT, Instant.ofEpochMilli(3), Instant.ofEpochMilli(4))
+      )
+    )
+  )
+
+  private var ds: DataSource                                   = scala.compiletime.uninitialized
+  private var locationRepository: LocationRepository           = scala.compiletime.uninitialized
+  private var voyageRepository: VoyageRepository               = scala.compiletime.uninitialized
+  private var handlingEventRepository: HandlingEventRepository = scala.compiletime.uninitialized
+  private var repo: MagnumCargoRepository                      = scala.compiletime.uninitialized
+
+  override def beforeEach(): Unit =
+    // Fresh in-memory H2 per test — DB_CLOSE_DELAY=-1 keeps the DB alive
+    // for the duration of the JVM, plus a unique URL prevents cross-test
+    // bleed if tests run in parallel.
+    val dbName = s"mem:magnum-poc-${System.nanoTime}"
+    val h2     = new JdbcDataSource
+    // Plain H2 — no MODE=PostgreSQL because Magnum's H2DbType already
+    // generates H2-native SQL.
+    h2.setURL(s"jdbc:h2:$dbName;DB_CLOSE_DELAY=-1")
+    h2.setUser("sa")
+    ds = h2
+
+    // Load schema. The file lives under src/test/resources/ which Mill
+    // puts on the test classpath. H2's `Statement.execute` only runs one
+    // statement at a time, so split on `;`.
+    val schema = Using.resource(getClass.getResourceAsStream("/magnum-cargo-schema.sql")) { in =>
+      Source.fromInputStream(in).mkString
+    }
+    Using.resource(ds.getConnection) { conn =>
+      Using.resource(conn.createStatement) { st =>
+        schema
+          .split(";")
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .foreach(st.execute)
+      }
+    }
+
+    locationRepository = mock(classOf[LocationRepository])
+    voyageRepository = mock(classOf[VoyageRepository])
+    handlingEventRepository = mock(classOf[HandlingEventRepository])
+
+    when(locationRepository.find(UnLocode("CNSHA"))).thenReturn(Some(SHA))
+    when(locationRepository.find(UnLocode("NLRTM"))).thenReturn(Some(RTM))
+    when(locationRepository.find(UnLocode("SEGOT"))).thenReturn(Some(GOT))
+    when(voyageRepository.find(VoyageNumber("V1"))).thenReturn(Some(voyage))
+    // Opaque-typed `TrackingId` can't be passed to Mockito's `any[T]`
+    // (`classOf[opaque type]` isn't a class type). Stub each value the
+    // tests exercise explicitly. Anything else returns null on the mock,
+    // which surfaces as a clear NPE if we accidentally read an unstubbed
+    // tracking id.
+    Seq("ABC", "XYZ", "MUT", "ONE", "TWO").foreach { id =>
+      when(handlingEventRepository.lookupHandlingHistoryOfCargo(TrackingId(id)))
+        .thenReturn(HandlingHistory.EMPTY)
+    }
+
+    repo = new MagnumCargoRepository(
+      ds,
+      locationRepository,
+      voyageRepository,
+      handlingEventRepository
+    )
+
+  test("nextTrackingId mints distinct ids") {
+    val a = repo.nextTrackingId()
+    val b = repo.nextTrackingId()
+    a should not equal b
+  }
+
+  test("find returns None for unknown tracking id") {
+    repo.find(TrackingId("ABSENT")) shouldBe None
+  }
+
+  test("store + find round-trips an un-routed cargo") {
+    val cargo = Cargo(TrackingId("ABC"), RouteSpecification(SHA, GOT, deadline))
+    repo.store(cargo)
+
+    val loaded = repo.find(TrackingId("ABC")).get
+    loaded.trackingId.idString shouldEqual "ABC"
+    loaded.origin shouldEqual SHA
+    loaded.routeSpecification.destination shouldEqual GOT
+    loaded.routeSpecification.arrivalDeadline shouldEqual deadline
+    loaded.itineraryOpt shouldBe None
+    loaded.delivery.routingStatus shouldEqual RoutingStatus.NOT_ROUTED
+    loaded.delivery.transportStatus shouldEqual TransportStatus.NOT_RECEIVED
+  }
+
+  test("store + find round-trips a routed cargo with two legs") {
+    val itinerary = Itinerary(
+      List(
+        Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20)),
+        Leg(voyage, RTM, GOT, Instant.ofEpochMilli(30), Instant.ofEpochMilli(40))
+      )
+    )
+    val cargo = Cargo(TrackingId("XYZ"), RouteSpecification(SHA, GOT, deadline))
+      .assignToRoute(itinerary)
+
+    repo.store(cargo)
+
+    val loaded = repo.find(TrackingId("XYZ")).get
+    loaded.itineraryOpt should not be empty
+    loaded.itineraryOpt.get.legs should have size 2
+    loaded.itineraryOpt.get.legs.head.loadLocation shouldEqual SHA
+    loaded.itineraryOpt.get.legs.head.unloadLocation shouldEqual RTM
+    loaded.itineraryOpt.get.legs(1).loadLocation shouldEqual RTM
+    loaded.itineraryOpt.get.legs(1).unloadLocation shouldEqual GOT
+    loaded.delivery.routingStatus shouldEqual RoutingStatus.ROUTED
+  }
+
+  test("store replaces an existing cargo's itinerary atomically") {
+    val initial = Cargo(TrackingId("MUT"), RouteSpecification(SHA, GOT, deadline))
+      .assignToRoute(
+        Itinerary(List(Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20))))
+      )
+    repo.store(initial)
+    repo.find(TrackingId("MUT")).get.itineraryOpt.get.legs should have size 1
+
+    // Re-route with two legs; the existing leg row should be replaced.
+    val rerouted = repo
+      .find(TrackingId("MUT"))
+      .get
+      .assignToRoute(
+        Itinerary(
+          List(
+            Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20)),
+            Leg(voyage, RTM, GOT, Instant.ofEpochMilli(30), Instant.ofEpochMilli(40))
+          )
+        )
+      )
+    repo.store(rerouted)
+
+    val loaded = repo.find(TrackingId("MUT")).get
+    loaded.itineraryOpt.get.legs should have size 2
+  }
+
+  test("getAll returns every persisted cargo") {
+    val c1 = Cargo(TrackingId("ONE"), RouteSpecification(SHA, GOT, deadline))
+    val c2 = Cargo(TrackingId("TWO"), RouteSpecification(SHA, RTM, deadline))
+    repo.store(c1)
+    repo.store(c2)
+
+    val all = repo.getAll
+    all.map(_.trackingId.idString) should contain theSameElementsAs Seq("ONE", "TWO")
+  }


### PR DESCRIPTION
## Summary

Proof-of-concept for the **Magnum** option of phase 9b persistence — replaces a single aggregate (`Cargo`) with a Magnum/H2-backed repository so we can compare the *real* code against the JPA option before committing to the full 4-aggregate port.

Lives alongside the in-memory `@Repository`-annotated impls; no Spring wiring. Boot behaviour unchanged.

## What this PoC demonstrates

- **Immutable Scala persistence model.** `CargoRow` / `LegRow` are `final case class` with `derives DbCodec`. No `var`, no no-arg constructor, no `@Entity` / `@OneToMany`.
- **Cross-aggregate references by id.** Voyage numbers and UN/Locodes stored as strings; resolved via `VoyageRepository` / `LocationRepository` during rehydration. Aligns with the DDD review recommendation (cross-aggregate refs by id, not object).
- **`Delivery` is not persisted.** Re-derived from handling history on every read (`Cargo.deriveDeliveryProgress`), so the snapshot can't drift from the `HandlingEvent` source-of-truth.
- **Transactions in the adapter.** Each method opens its own `transact(ds) { ... }` / `connect(ds) { ... }` block. If we adopt Magnum, application services drop `@Transactional`.
- **Custom `DbCodec[Instant]`.** Magnum 1.3 ships `OffsetDateTime` natively; `Instant` is a `biMap` over it.

## Friction encountered (relevant if we proceed with the full port)

| Issue | Workaround used | Implication for full port |
| --- | --- | --- |
| Mockito's `any[T](classOf[T])` rejects opaque `TrackingId` | Explicit stubs per id | Build a tiny `IdMatchers` helper |
| `@Table(name = …)` doesn't exist in Magnum 1.3; table name comes from class name via `SqlNameMapper` | Tables named `cargo_row` / `leg_row` | Acceptable convention; document in CLAUDE.md |
| H2 with `MODE=PostgreSQL` rejected `bigint identity` | Plain H2 + `bigint generated always as identity` | Schema portability across H2/PG needs care |

## Tests

`MagnumCargoRepositoryTest` — 6 tests against fresh H2 in-memory per test:

- `nextTrackingId mints distinct ids`
- `find returns None for unknown tracking id`
- `store + find round-trips an un-routed cargo`
- `store + find round-trips a routed cargo with two legs`
- `store replaces an existing cargo's itinerary atomically`
- `getAll returns every persisted cargo`

Full suite: **79 tests pass** (73 baseline + 6 new).

## Test plan

- [ ] `mill ddd.compile` — clean
- [ ] `mill ddd.test` — 79 / 79
- [ ] `mill 'ddd.test.testOnly *MagnumCargoRepositoryTest'` — 6 / 6 in isolation
- [ ] `mill __.checkFormat` — clean
- [ ] CI green on the PR

## Decision wanted

Look at:

- `MagnumCargoRepository.scala` — about 170 lines, including ~50 lines of mapping helpers
- `CargoRow.scala` / `LegRow.scala` — about 25 lines each, mostly data
- `MagnumCargoRepositoryTest.scala` — what test setup costs (mocks for collaborator repos + schema load)

Compare to the equivalent JPA shape — `@Entity class JpaCargo { var ... }` + Spring Data interface + mapper. If the Magnum version reads cleaner and the friction list above is acceptable, the full port is ~3× this PR's size (Location + Voyage + HandlingEvent following the same pattern, plus Spring `@Profile("magnum")` wiring and a Flyway/Liquibase migration to replace the test-only schema).

If we go ahead, **this PR stays as-is** as the foundation, then a follow-up adds the remaining three aggregates + wiring. If we go with JPA instead, **close this PR**; no master changes.