### PR TITLE
poc: JPA-backed CargoRepository (phase 9b option B)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -67,6 +67,9 @@ object ddd extends ScalaModule with ScalafmtModule {
     mvn"commons-io:commons-io:2.18.0",
     // HSQLDB for the dev profile + integration tests (matches upstream Java).
     mvn"org.hsqldb:hsqldb:2.7.4",
+    // H2 — used by the phase 9b JPA PoC. Spring Boot's data-jpa autoconfig
+    // picks it up automatically when no other DataSource is configured.
+    mvn"com.h2database:h2:2.3.232",
     // jackson-module-scala lets Jackson serialize/deserialize Scala `Option`
     // and case classes natively. Used by the JMS payload serializer so we
     // can drop `scala` from the broker's setTrustedPackages list (any future

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoEntity.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoEntity.scala
@@ -1,0 +1,79 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import jakarta.persistence.{
+  CascadeType,
+  Column,
+  Entity,
+  FetchType,
+  GeneratedValue,
+  GenerationType,
+  Id,
+  OneToMany,
+  OrderBy,
+  Table
+}
+import java.time.Instant
+
+import scala.beans.BeanProperty
+import scala.compiletime.uninitialized
+
+/**
+ * JPA entity mirroring the [[se.citerus.dddsample.domain.model.cargo.Cargo]]
+ * aggregate.
+ *
+ * Pure persistence model — separate from the domain entity per D1. Lives
+ * with a Scala-shaped-like-Java surface (mutable `var` fields, public
+ * no-arg constructor, JPA annotations) because JPA's reflection-based
+ * machinery requires it. The mapper class [[CargoMapper]] converts this
+ * row to/from the immutable
+ * [[se.citerus.dddsample.domain.model.cargo.Cargo]].
+ *
+ * Cross-aggregate references stored by **id** (UN/Locode strings, voyage
+ * number strings) rather than `@ManyToOne` to other JPA entities. This
+ * keeps the JPA model focused on Cargo's own aggregate boundary and
+ * avoids the lazy-loading proxy spaghetti you get from cross-aggregate
+ * `@ManyToOne(fetch = LAZY)`.
+ */
+@Entity
+@Table(name = "cargo")
+class CargoEntity:
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @BeanProperty
+  var id: java.lang.Long = uninitialized
+
+  @Column(name = "tracking_id", unique = true, nullable = false)
+  @BeanProperty
+  var trackingId: String = uninitialized
+
+  @Column(name = "origin_un_locode", nullable = false)
+  @BeanProperty
+  var originUnLocode: String = uninitialized
+
+  @Column(name = "spec_destination_un_locode", nullable = false)
+  @BeanProperty
+  var specDestinationUnLocode: String = uninitialized
+
+  @Column(name = "spec_arrival_deadline", nullable = false)
+  @BeanProperty
+  var specArrivalDeadline: Instant = uninitialized
+
+  // Aggregate-owned child collection. Cascade.ALL + orphanRemoval=true means
+  // the cargo's lifecycle owns its legs (no orphans, no manual leg deletes).
+  //
+  // `targetEntity = classOf[LegEntity]` is set explicitly because Scala 3's
+  // bytecode for `@BeanProperty`-derived accessors on a parameterised
+  // `java.util.List[LegEntity]` field doesn't always preserve the type
+  // parameter for Hibernate's reflection lookup — without this hint,
+  // Hibernate sees a raw `List` and aborts with an AnnotationException.
+  @OneToMany(
+    mappedBy = "cargo",
+    cascade = Array(CascadeType.ALL),
+    fetch = FetchType.EAGER,
+    orphanRemoval = true,
+    targetEntity = classOf[LegEntity]
+  )
+  @OrderBy("legIndex ASC")
+  @BeanProperty
+  var legs: java.util.List[LegEntity] = new java.util.ArrayList[LegEntity]()

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoEntityRepository.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoEntityRepository.scala
@@ -1,0 +1,20 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import java.util.Optional
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * Spring Data JPA repository for [[CargoEntity]] — the low-level data
+ * access port. Spring generates the proxy at runtime; we get
+ * `save / findById / findAll / deleteAll` for free, plus a
+ * `findByTrackingId` derived query.
+ *
+ * This is **not** the [[se.citerus.dddsample.domain.model.cargo.CargoRepository]]
+ * the domain expects — it returns persistence entities, not domain
+ * aggregates. The adapter [[JpaCargoRepository]] bridges the two.
+ */
+trait CargoEntityRepository extends JpaRepository[CargoEntity, java.lang.Long]:
+
+  /** Spring Data derives the query from the method name. */
+  def findByTrackingId(trackingId: String): Optional[CargoEntity]

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoMapper.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/CargoMapper.scala
@@ -1,0 +1,102 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import scala.jdk.CollectionConverters.*
+
+import se.citerus.dddsample.domain.model.cargo.*
+import se.citerus.dddsample.domain.model.location.{LocationRepository, UnLocode}
+import se.citerus.dddsample.domain.model.voyage.{VoyageNumber, VoyageRepository}
+
+/**
+ * Bidirectional mapping between mutable [[CargoEntity]] (JPA's world) and
+ * the immutable [[Cargo]] aggregate (domain's world).
+ *
+ * The hardest direction is **row → aggregate**: we have only ids for
+ * Voyage and Location in the row, so we resolve them via the other
+ * domain repositories. `Delivery` is re-derived from the cargo's
+ * handling history rather than persisted — same convention as the
+ * Magnum PoC and the in-memory repo.
+ */
+final class CargoMapper(
+    locationRepository: LocationRepository,
+    voyageRepository: VoyageRepository,
+    handlingEventRepository: se.citerus.dddsample.domain.model.handling.HandlingEventRepository
+):
+
+  // ---- Aggregate → Entity ------------------------------------------------
+
+  /**
+   * Apply the aggregate's state onto an *existing* entity (typically one
+   * fetched by tracking id) or onto a fresh empty `CargoEntity` if the
+   * cargo is new. Mutating an already-managed entity is JPA-idiomatic.
+   */
+  def applyTo(entity: CargoEntity, cargo: Cargo): CargoEntity =
+    entity.trackingId = cargo.trackingId.idString
+    entity.originUnLocode = cargo.origin.unLocode.idString
+    entity.specDestinationUnLocode = cargo.routeSpecification.destination.unLocode.idString
+    entity.specArrivalDeadline = cargo.routeSpecification.arrivalDeadline
+
+    // Refresh legs by clearing + repopulating; orphanRemoval=true on the
+    // @OneToMany means Hibernate issues deletes for the dropped legs and
+    // inserts for the new ones in one flush.
+    entity.legs.clear()
+    cargo.itineraryOpt.foreach { itin =>
+      itin.legs.zipWithIndex.foreach { case (leg, idx) =>
+        val legEntity = new LegEntity
+        legEntity.cargo = entity
+        legEntity.legIndex = idx
+        legEntity.voyageNumber = leg.voyage.voyageNumber.idString
+        legEntity.loadUnLocode = leg.loadLocation.unLocode.idString
+        legEntity.unloadUnLocode = leg.unloadLocation.unLocode.idString
+        legEntity.loadTime = leg.loadTime
+        legEntity.unloadTime = leg.unloadTime
+        entity.legs.add(legEntity)
+      }
+    }
+    entity
+
+  /** Convenience: produce a fresh CargoEntity from a domain Cargo. */
+  def toEntity(cargo: Cargo): CargoEntity = applyTo(new CargoEntity, cargo)
+
+  // ---- Entity → Aggregate ------------------------------------------------
+
+  def toAggregate(entity: CargoEntity): Cargo =
+    val origin = locationRepository
+      .find(UnLocode(entity.originUnLocode))
+      .getOrElse(
+        throw new IllegalStateException(s"Unknown origin UN/Locode: ${entity.originUnLocode}")
+      )
+    val destination = locationRepository
+      .find(UnLocode(entity.specDestinationUnLocode))
+      .getOrElse(
+        throw new IllegalStateException(
+          s"Unknown destination UN/Locode: ${entity.specDestinationUnLocode}"
+        )
+      )
+    val spec     = RouteSpecification(origin, destination, entity.specArrivalDeadline)
+    val withSpec = Cargo(TrackingId(entity.trackingId), spec)
+
+    val withItinerary =
+      if entity.legs.isEmpty then withSpec
+      else
+        val legs = entity.legs.asScala.toList.map { l =>
+          Leg(
+            voyageRepository
+              .find(VoyageNumber(l.voyageNumber))
+              .getOrElse(throw new IllegalStateException(s"Unknown voyage: ${l.voyageNumber}")),
+            locationRepository
+              .find(UnLocode(l.loadUnLocode))
+              .getOrElse(throw new IllegalStateException(s"Unknown load loc: ${l.loadUnLocode}")),
+            locationRepository
+              .find(UnLocode(l.unloadUnLocode))
+              .getOrElse(
+                throw new IllegalStateException(s"Unknown unload loc: ${l.unloadUnLocode}")
+              ),
+            l.loadTime,
+            l.unloadTime
+          )
+        }
+        withSpec.assignToRoute(Itinerary(legs))
+
+    val history =
+      handlingEventRepository.lookupHandlingHistoryOfCargo(withItinerary.trackingId)
+    withItinerary.deriveDeliveryProgress(history)

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaCargoRepository.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaCargoRepository.scala
@@ -1,0 +1,53 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import java.util.UUID
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+
+import org.springframework.transaction.annotation.Transactional
+
+import se.citerus.dddsample.domain.model.cargo.{Cargo, CargoRepository, TrackingId}
+
+/**
+ * Adapter implementing the domain [[CargoRepository]] in terms of:
+ *
+ *   - the Spring Data [[CargoEntityRepository]] for CRUD
+ *   - the [[CargoMapper]] for entity ↔ aggregate translation
+ *
+ * Mirrors the Magnum-PoC adapter shape, with two notable differences:
+ *
+ *   1. **Transactions via `@Transactional`** — the Spring proxy intercepts
+ *      each method and opens / commits the transaction. Application
+ *      services keep their own `@Transactional` boundary, which composes
+ *      cleanly (propagation defaults to REQUIRED).
+ *   2. **Refresh-by-mutation, not refresh-by-replace.** On `store`, we
+ *      fetch the existing managed entity and mutate it via the mapper —
+ *      `orphanRemoval=true` + cascade-all let Hibernate flush the right
+ *      inserts/deletes for the legs collection.
+ */
+@org.springframework.stereotype.Repository
+final class JpaCargoRepository(
+    entityRepository: CargoEntityRepository,
+    mapper: CargoMapper
+) extends CargoRepository:
+
+  @Transactional(readOnly = true)
+  override def find(trackingId: TrackingId): Option[Cargo] =
+    entityRepository.findByTrackingId(trackingId.idString).toScala.map(mapper.toAggregate)
+
+  @Transactional(readOnly = true)
+  override def getAll: List[Cargo] =
+    entityRepository.findAll().asScala.toList.map(mapper.toAggregate)
+
+  @Transactional
+  override def store(cargo: Cargo): Unit =
+    val entity = entityRepository
+      .findByTrackingId(cargo.trackingId.idString)
+      .orElseGet(() => new CargoEntity)
+    mapper.applyTo(entity, cargo)
+    entityRepository.save(entity)
+    ()
+
+  override def nextTrackingId(): TrackingId =
+    TrackingId(UUID.randomUUID().toString.toUpperCase.substring(0, 10))

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaConfig.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaConfig.scala
@@ -1,0 +1,21 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+
+/**
+ * Spring config enabling JPA repository + entity scanning under this
+ * package. Without this, `@SpringBootApplication`'s default classpath
+ * scan picks up the `@Entity` / `JpaRepository` interfaces, but
+ * `@DataJpaTest` slices the context and needs the explicit hints.
+ *
+ * Active by default once present on the classpath. To run the app
+ * without JPA, exclude this config from component scanning *or* keep
+ * the `application.properties` autoconfig excludes; tests opt in via
+ * `@TestPropertySource(properties = "spring.autoconfigure.exclude=")`.
+ */
+@Configuration
+@EntityScan(basePackageClasses = Array(classOf[CargoEntity]))
+@EnableJpaRepositories(basePackageClasses = Array(classOf[CargoEntityRepository]))
+class JpaConfig

--- a/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/LegEntity.scala
+++ b/src/main/scala/se/citerus/dddsample/infrastructure/persistence/jpa/LegEntity.scala
@@ -1,0 +1,64 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import jakarta.persistence.{
+  Column,
+  Entity,
+  FetchType,
+  GeneratedValue,
+  GenerationType,
+  Id,
+  JoinColumn,
+  ManyToOne,
+  Table
+}
+import java.time.Instant
+
+import scala.beans.BeanProperty
+import scala.compiletime.uninitialized
+
+/**
+ * JPA entity for one entry in a Cargo's `Itinerary`.
+ *
+ * Owned by [[CargoEntity]] via a bidirectional `@OneToMany` / `@ManyToOne`.
+ * The back-reference is required by Hibernate for the orphan-removal +
+ * cascade-all relationship that mirrors aggregate ownership.
+ */
+@Entity
+@Table(name = "leg")
+class LegEntity:
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @BeanProperty
+  var id: java.lang.Long = uninitialized
+
+  // The parent in the aggregate. LAZY because we always traverse from the
+  // Cargo down, never the other way.
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "cargo_id", nullable = false)
+  @BeanProperty
+  var cargo: CargoEntity = uninitialized
+
+  @Column(name = "leg_index", nullable = false)
+  @BeanProperty
+  var legIndex: Int = 0
+
+  @Column(name = "voyage_number", nullable = false)
+  @BeanProperty
+  var voyageNumber: String = uninitialized
+
+  @Column(name = "load_un_locode", nullable = false)
+  @BeanProperty
+  var loadUnLocode: String = uninitialized
+
+  @Column(name = "unload_un_locode", nullable = false)
+  @BeanProperty
+  var unloadUnLocode: String = uninitialized
+
+  @Column(name = "load_time", nullable = false)
+  @BeanProperty
+  var loadTime: Instant = uninitialized
+
+  @Column(name = "unload_time", nullable = false)
+  @BeanProperty
+  var unloadTime: Instant = uninitialized

--- a/src/test/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaCargoRepositoryTest.scala
+++ b/src/test/scala/se/citerus/dddsample/infrastructure/persistence/jpa/JpaCargoRepositoryTest.scala
@@ -1,0 +1,200 @@
+package se.citerus.dddsample.infrastructure.persistence.jpa
+
+import java.time.Instant
+
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.{Bean, Import}
+import org.springframework.test.context.TestContextManager
+import org.springframework.test.context.TestPropertySource
+
+import se.citerus.dddsample.domain.model.cargo.*
+import se.citerus.dddsample.domain.model.handling.{HandlingEventRepository, HandlingHistory}
+import se.citerus.dddsample.domain.model.location.{Location, LocationRepository, UnLocode}
+import se.citerus.dddsample.domain.model.voyage.{
+  CarrierMovement,
+  Schedule,
+  Voyage,
+  VoyageNumber,
+  VoyageRepository
+}
+
+/**
+ * Integration test for the JPA-based Cargo persistence layer.
+ *
+ * `@DataJpaTest` slices the Spring context to JPA + Spring Data only, and
+ * brings up an embedded H2 in-memory database with Hibernate's
+ * `create-drop` schema generation. Each test runs in its own transaction
+ * which rolls back at teardown, isolating fixtures.
+ *
+ * `TestContextManager` bridges Spring's test-context machinery to
+ * ScalaTest — `@Autowired` fields populate in `beforeAll`.
+ *
+ * The `spring.autoconfigure.exclude=` override clears the global exclude
+ * list from `application.properties` (which disables JPA in production
+ * until we wire it). Without this override Hibernate doesn't start.
+ */
+@DataJpaTest
+@TestPropertySource(properties = Array("spring.autoconfigure.exclude="))
+@Import(Array(classOf[JpaCargoRepositoryTest.TestConfig]))
+class JpaCargoRepositoryTest extends AnyFunSuite with Matchers with BeforeAndAfterAll:
+
+  // @Autowired field populated by TestContextManager in beforeAll.
+  // Typed as the domain interface, not the concrete `final class
+  // JpaCargoRepository`, because `spring.aop.proxy-target-class=false`
+  // makes Spring wrap the @Transactional adapter in a JDK interface-based
+  // proxy. The proxy implements `CargoRepository` but isn't a
+  // `JpaCargoRepository`.
+  @Autowired private var repository: CargoRepository = scala.compiletime.uninitialized
+
+  override def beforeAll(): Unit =
+    new TestContextManager(getClass).prepareTestInstance(this)
+
+  private val SHA = Location(UnLocode("CNSHA"), "Shanghai")
+  private val RTM = Location(UnLocode("NLRTM"), "Rotterdam")
+  private val GOT = Location(UnLocode("SEGOT"), "Gothenburg")
+
+  private val deadline = Instant.parse("2026-12-01T00:00:00Z")
+
+  private val voyage = new Voyage(
+    VoyageNumber("V1"),
+    Schedule(
+      List(
+        CarrierMovement(SHA, RTM, Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)),
+        CarrierMovement(RTM, GOT, Instant.ofEpochMilli(3), Instant.ofEpochMilli(4))
+      )
+    )
+  )
+
+  test("find returns None for unknown tracking id") {
+    repository.find(TrackingId("ABSENT")) shouldBe None
+  }
+
+  test("store + find round-trips an un-routed cargo") {
+    val cargo = Cargo(TrackingId("ABC"), RouteSpecification(SHA, GOT, deadline))
+    repository.store(cargo)
+
+    val loaded = repository.find(TrackingId("ABC")).get
+    loaded.trackingId.idString shouldEqual "ABC"
+    loaded.origin shouldEqual SHA
+    loaded.routeSpecification.destination shouldEqual GOT
+    loaded.routeSpecification.arrivalDeadline shouldEqual deadline
+    loaded.itineraryOpt shouldBe None
+    loaded.delivery.routingStatus shouldEqual RoutingStatus.NOT_ROUTED
+    loaded.delivery.transportStatus shouldEqual TransportStatus.NOT_RECEIVED
+  }
+
+  test("store + find round-trips a routed cargo with two legs") {
+    val itinerary = Itinerary(
+      List(
+        Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20)),
+        Leg(voyage, RTM, GOT, Instant.ofEpochMilli(30), Instant.ofEpochMilli(40))
+      )
+    )
+    val cargo = Cargo(TrackingId("XYZ"), RouteSpecification(SHA, GOT, deadline))
+      .assignToRoute(itinerary)
+    repository.store(cargo)
+
+    val loaded = repository.find(TrackingId("XYZ")).get
+    loaded.itineraryOpt should not be empty
+    loaded.itineraryOpt.get.legs should have size 2
+    loaded.itineraryOpt.get.legs.head.loadLocation shouldEqual SHA
+    loaded.itineraryOpt.get.legs.head.unloadLocation shouldEqual RTM
+    loaded.itineraryOpt.get.legs(1).loadLocation shouldEqual RTM
+    loaded.itineraryOpt.get.legs(1).unloadLocation shouldEqual GOT
+    loaded.delivery.routingStatus shouldEqual RoutingStatus.ROUTED
+  }
+
+  test("store replaces an existing cargo's itinerary atomically") {
+    val initial = Cargo(TrackingId("MUT"), RouteSpecification(SHA, GOT, deadline))
+      .assignToRoute(
+        Itinerary(List(Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20))))
+      )
+    repository.store(initial)
+    repository.find(TrackingId("MUT")).get.itineraryOpt.get.legs should have size 1
+
+    val rerouted = repository
+      .find(TrackingId("MUT"))
+      .get
+      .assignToRoute(
+        Itinerary(
+          List(
+            Leg(voyage, SHA, RTM, Instant.ofEpochMilli(10), Instant.ofEpochMilli(20)),
+            Leg(voyage, RTM, GOT, Instant.ofEpochMilli(30), Instant.ofEpochMilli(40))
+          )
+        )
+      )
+    repository.store(rerouted)
+
+    repository.find(TrackingId("MUT")).get.itineraryOpt.get.legs should have size 2
+  }
+
+  test("getAll returns every persisted cargo") {
+    val c1 = Cargo(TrackingId("ONE"), RouteSpecification(SHA, GOT, deadline))
+    val c2 = Cargo(TrackingId("TWO"), RouteSpecification(SHA, RTM, deadline))
+    repository.store(c1)
+    repository.store(c2)
+
+    val ids = repository.getAll.map(_.trackingId.idString).toSet
+    ids should contain allOf ("ONE", "TWO")
+  }
+
+object JpaCargoRepositoryTest:
+
+  /**
+   * Test-only Spring config: provides the JpaCargoRepository under test
+   * plus mocked collaborator repositories. `@DataJpaTest` doesn't
+   * auto-scan `@Repository`-annotated classes outside the JPA slice, so
+   * we wire them by hand here.
+   */
+  @TestConfiguration
+  class TestConfig:
+
+    private val SHA = Location(UnLocode("CNSHA"), "Shanghai")
+    private val RTM = Location(UnLocode("NLRTM"), "Rotterdam")
+    private val GOT = Location(UnLocode("SEGOT"), "Gothenburg")
+
+    private val voyage = new Voyage(
+      VoyageNumber("V1"),
+      Schedule(
+        List(
+          CarrierMovement(SHA, RTM, Instant.ofEpochMilli(1), Instant.ofEpochMilli(2)),
+          CarrierMovement(RTM, GOT, Instant.ofEpochMilli(3), Instant.ofEpochMilli(4))
+        )
+      )
+    )
+
+    @Bean def locationRepository: LocationRepository =
+      val m = mock(classOf[LocationRepository])
+      when(m.find(UnLocode("CNSHA"))).thenReturn(Some(SHA))
+      when(m.find(UnLocode("NLRTM"))).thenReturn(Some(RTM))
+      when(m.find(UnLocode("SEGOT"))).thenReturn(Some(GOT))
+      m
+
+    @Bean def voyageRepository: VoyageRepository =
+      val m = mock(classOf[VoyageRepository])
+      when(m.find(VoyageNumber("V1"))).thenReturn(Some(voyage))
+      m
+
+    @Bean def handlingEventRepository: HandlingEventRepository =
+      val m = mock(classOf[HandlingEventRepository])
+      Seq("ABC", "XYZ", "MUT", "ONE", "TWO").foreach { id =>
+        when(m.lookupHandlingHistoryOfCargo(TrackingId(id))).thenReturn(HandlingHistory.EMPTY)
+      }
+      m
+
+    @Bean def cargoMapper(
+        locationRepository: LocationRepository,
+        voyageRepository: VoyageRepository,
+        handlingEventRepository: HandlingEventRepository
+    ): CargoMapper = new CargoMapper(locationRepository, voyageRepository, handlingEventRepository)
+
+    @Bean def jpaCargoRepository(
+        entityRepository: CargoEntityRepository,
+        mapper: CargoMapper
+    ): JpaCargoRepository = new JpaCargoRepository(entityRepository, mapper)


### PR DESCRIPTION
## Summary

Parallel PoC to #101 — same aggregate (`Cargo`), JPA shape instead of Magnum, so the two can be compared side-by-side. Like #101, this lives alongside the in-memory repo and is **not** wired into the running app.

## What this PoC demonstrates

- **JPA persistence model** with the canonical Spring Boot 3.3 / Jakarta EE 10 / Hibernate 6 stack: `@Entity`, `@Table`, `@OneToMany` / `@ManyToOne`, `@Column`, `@GeneratedValue`.
- **Spring Data JPA repository** (`CargoEntityRepository extends JpaRepository`) with a derived `findByTrackingId` query.
- **Domain mapper** (`CargoMapper`) that converts between the mutable `CargoEntity` and the immutable domain `Cargo`. Cross-aggregate references (UN/Locode, voyage number) stay as strings in storage; resolved via the other domain repositories during rehydration.
- **`@Transactional` adapter** (`JpaCargoRepository`) composes with Spring's transaction manager — application services keep their own `@Transactional` boundaries unchanged.
- **`@DataJpaTest` integration test** — real H2 + Hibernate, transactional rollback per test.

## Friction encountered (relevant for the full port)

| Issue | Workaround used | Implication for full port |
| --- | --- | --- |
| Mutable `@Entity` class is un-Scala — `var` fields + public no-arg constructor required | `@BeanProperty` + `scala.compiletime.uninitialized` | Persistence layer wears the shape visibly; documented at the top of every entity file |
| `@OneToMany` on a Scala-generated `java.util.List[LegEntity]` was seen as raw by Hibernate (Scala 3 BeanProperty erases the type parameter for reflection) | Explicit `targetEntity = classOf[LegEntity]` | Add to every `@OneToMany` / `@ManyToMany`. Worth a CLAUDE.md note. |
| `spring.aop.proxy-target-class=false` + `final class` adapter ⇒ Spring uses JDK interface proxies; can't `@Autowired` the concrete adapter type | Tests `@Autowire CargoRepository` (the domain trait) instead | Documentation only; the right typing anyway |
| `@DataJpaTest` defies the production `spring.autoconfigure.exclude` list | `@TestPropertySource(properties = Array("spring.autoconfigure.exclude="))` per test class | One-line override; minor noise |

## Tests

`JpaCargoRepositoryTest` — 5 tests against `@DataJpaTest`-provisioned H2:

- `find returns None for unknown tracking id`
- `store + find round-trips an un-routed cargo`
- `store + find round-trips a routed cargo with two legs`
- `store replaces an existing cargo's itinerary atomically`
- `getAll returns every persisted cargo`

Full suite: **78 tests pass** (73 baseline + 5 new).

## Side-by-side with #101 (Magnum)

| | #101 Magnum | #95 (this PR) JPA |
| --- | --- | --- |
| Persistence model | `final case class … derives DbCodec` (~50 LoC total for both row types + creators) | `class CargoEntity { var … }` + JPA annotations (~75 LoC for two entities) |
| Mapper | `rehydrate` + `toCargoCreator` inline in adapter (~80 LoC) | Dedicated `CargoMapper` class (~80 LoC) |
| Repository interface | None — Magnum's `Repo` typeclass is summoned in the adapter | `CargoEntityRepository` Spring Data interface |
| Transactions | `transact(ds)` block inside each adapter method | `@Transactional` on each adapter method, composes with Spring TM |
| Schema | Hand-written DDL in test resources | Hibernate `create-drop` autogenerated |
| Test bootstrap | Raw `JdbcDataSource` + manual schema load (~30 LoC of test setup) | `@DataJpaTest` slice + `TestContextManager` + `@TestConfiguration` (~45 LoC) |
| Total new LoC | 515 (incl. 6 tests) | 542 (incl. 5 tests) |
| Test count | 6 | 5 |
| Spring Boot integration cost | Drop `@Transactional` from app services; new dependency on Magnum | Zero — JPA composes with existing `@Transactional` boundaries |
| Scala readability | High; immutable case classes + `sql"…"` | Lower; `var` everywhere, framework-shaped |
| Teaching angle | "Persistence is three immutable layers (row ↔ creator ↔ aggregate)" | "Heavyweight ORM lives behind a mapper so the domain stays clean" |

## Decision

Look at both branches, decide which lesson the codebase should teach:

- **Merge #101 (Magnum)** if Scala-coherent persistence is more valuable than Spring/JPA familiarity for the readership
- **Merge this PR (JPA)** if showing how to live with the canonical Spring stack is the lesson
- **Merge neither** and stay on in-memory repos (phase 9b deferred indefinitely)
- **Merge both eventually**, with `@Profile`-gated wiring so one or the other activates at runtime — possible but doubles the maintenance surface for not much teaching gain

## Test plan

- [ ] `mill ddd.compile` — clean
- [ ] `mill ddd.test` — 78 / 78
- [ ] `mill 'ddd.test.testOnly *JpaCargoRepositoryTest'` — 5 / 5 in isolation
- [ ] `mill __.checkFormat` — clean
- [ ] CI green on the PR