### PR TITLE
chore(deps): activemq 6.1.5 -> 6.1.8 + jackson-module-scala 2.18.2 -> 2.19.1

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -72,8 +72,10 @@ object ddd extends ScalaModule with ScalafmtModule {
     // can drop `scala` from the broker's setTrustedPackages list (any future
     // attacker reaching the queue can't pivot through Java deserialization
     // of `scala.Some` / `scala.None` etc.). Version-aligned with the
-    // Jackson 2.18.x that Spring Boot 3.3.10 brings in transitively.
-    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.18.2",
+    // jackson-databind 2.19.x that ActiveMQ 6.1.8 brings in transitively
+    // — running module-scala against a newer databind aborts the JMS
+    // serializer at construction time with a JsonMappingException.
+    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.19.1",
     // Magnum + H2 — PoC for the Magnum-based phase 9b persistence layer.
     // Lives alongside the in-memory repos; not yet wired into Spring beans
     // (the in-memory `@Repository`-annotated impls are still authoritative).

--- a/build.mill
+++ b/build.mill
@@ -60,8 +60,8 @@ object ddd extends ScalaModule with ScalafmtModule {
     mvn"org.springframework.boot:spring-boot-starter-validation:$SpringBootVersion",
     mvn"org.springframework.boot:spring-boot-starter-thymeleaf:$SpringBootVersion",
     // ActiveMQ Classic 6.x (Jakarta) for in-process broker + Spring wiring.
-    mvn"org.apache.activemq:activemq-broker:6.1.5",
-    mvn"org.apache.activemq:activemq-spring:6.1.5",
+    mvn"org.apache.activemq:activemq-broker:6.1.8",
+    mvn"org.apache.activemq:activemq-spring:6.1.8",
     // Apache Commons utilities — null checks, string utils, builders.
     mvn"org.apache.commons:commons-lang3:3.20.0",
     mvn"commons-io:commons-io:2.18.0",


### PR DESCRIPTION
## Summary
- Re-applies Scala Steward's [#103](https://github.com/oluies/ddd-sample-scala/pull/103) bump of `activemq-broker` and `activemq-spring` from 6.1.5 → 6.1.8.
- Adds a follow-up bump of `jackson-module-scala` 2.18.2 → 2.19.1 so the runtime version-compat check stops aborting `HandlingEventRegistrationAttemptJsonTest`.

ActiveMQ 6.1.8 transitively brings in `jackson-databind` 2.19.1, which fails the strict-range compatibility check in `jackson-module-scala` 2.18.2:

\`\`\`
JsonMappingException: Scala module 2.18.2 requires Jackson Databind version >= 2.18.0 and < 2.19.0 - Found jackson-databind version 2.19.1
\`\`\`

The PR carries the two commits authored together. Originally tried to fix #103 in place, but its head branch lives in the `scala-steward` fork and isn't push-accessible from my side.

## Test plan
- [x] \`mill ddd.test\` is green locally (90 tests).
- [ ] CI \`mill test (Java 21)\` passes.
- [ ] Snyk check passes.