### PR TITLE
chore(deps): activemq 6.1.8 -> 6.2.6 + jackson-module-scala 2.19.1 -> 2.21.1

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -60,8 +60,8 @@ object ddd extends ScalaModule with ScalafmtModule {
     mvn"org.springframework.boot:spring-boot-starter-validation:$SpringBootVersion",
     mvn"org.springframework.boot:spring-boot-starter-thymeleaf:$SpringBootVersion",
     // ActiveMQ Classic 6.x (Jakarta) for in-process broker + Spring wiring.
-    mvn"org.apache.activemq:activemq-broker:6.1.8",
-    mvn"org.apache.activemq:activemq-spring:6.1.8",
+    mvn"org.apache.activemq:activemq-broker:6.2.6",
+    mvn"org.apache.activemq:activemq-spring:6.2.6",
     // Apache Commons utilities — null checks, string utils, builders.
     mvn"org.apache.commons:commons-lang3:3.20.0",
     mvn"commons-io:commons-io:2.18.0",
@@ -72,10 +72,10 @@ object ddd extends ScalaModule with ScalafmtModule {
     // can drop `scala` from the broker's setTrustedPackages list (any future
     // attacker reaching the queue can't pivot through Java deserialization
     // of `scala.Some` / `scala.None` etc.). Version-aligned with the
-    // jackson-databind 2.19.x that ActiveMQ 6.1.8 brings in transitively
+    // jackson-databind 2.21.x that ActiveMQ 6.2.6 brings in transitively
     // — running module-scala against a newer databind aborts the JMS
     // serializer at construction time with a JsonMappingException.
-    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.19.1",
+    mvn"com.fasterxml.jackson.module::jackson-module-scala:2.21.1",
     // Magnum + H2 — PoC for the Magnum-based phase 9b persistence layer.
     // Lives alongside the in-memory repos; not yet wired into Spring beans
     // (the in-memory `@Repository`-annotated impls are still authoritative).


### PR DESCRIPTION
## Summary

Replaces #105.

- Bumps `activemq-broker` and `activemq-spring` 6.1.8 → 6.2.6 (Steward's original request).
- Realigns `jackson-module-scala` 2.19.1 → 2.21.1 because ActiveMQ 6.2.6 transitively pulls jackson-databind 2.21.1, which trips module-scala 2.19.1's strict-range compat check (`>= 2.19.0 and < 2.20.0`).

Without the second bump, `HandlingEventRegistrationAttemptJsonTest` aborts at module init with `JsonMappingException`. This is the same pattern that took down #103 and was fixed by #104.

#105 itself can't be patched directly — its head branch lives in the Scala Steward fork and isn't writable to the maintainer side.

## Test plan

- [x] `mill ddd.test` — 138/138 SUCCESS locally on this branch
- [ ] CI green